### PR TITLE
Added flag to curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 Get fresh free proxies. All proxies in this list are checked for hiding your ip address, non-modified html/js code and https protocol support. Updates every hour.
 
 ### Usage:
+~~`curl https://proxy.l337.tech/txt`~~
+
+__*SSL Certificate has expired, Until it has been renewed, use this command instead:*__
 ```bash
-curl https://proxy.l337.tech/txt
+curl -k https://proxy.l337.tech/txt
 ```
 ![Screenshot](https://github.com/DanyaDaro/free-proxy-list/blob/master/github.png?raw=true)
 


### PR DESCRIPTION
SSL has expired on proxy.l337.tech, so I added a flag to the curl command to ignore the warning. If run without the `-k` flag, we get this:

> curl https://proxy.l337.tech/txt
curl: (35) schannel: next InitializeSecurityContext failed: SEC_E_CERT_EXPIRED (0x80090328) - The received certificate has expired.